### PR TITLE
Escape the {}'s in the regex to fix unescaped left brace in regex is …

### DIFF
--- a/script/cpan2aur
+++ b/script/cpan2aur
@@ -765,7 +765,7 @@ sub get_pkgbuild_info
 
     my ($dist_name, $dist_ver) = $pkgbuild_txt
         =~ m{ (?: DIST_DIR | ^_distdir )=
-              "\${srcdir}/ ( [\w-]+ ) - v? ( [\d.]+ ) /? " }xms;
+              "\$\{srcdir\}/ ( [\w-]+ ) - v? ( [\d.]+ ) /? " }xms;
 
     my ($pkgrel) = $pkgbuild_txt
         =~ m{ ^ pkgrel = ['"]? ( \d+ ) ['"]? }xms;


### PR DESCRIPTION
Right now on Perl 5.22, cpan2aur throws a deprecation warning:

    ([J:3]jnbek(0)@genesis2[/tmp]% cpan2aur Mojolicious                                                  [08/18/15][20:14:42])
    Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/ (?: DIST_DIR | ^_distdir )=
              "\${ <-- HERE srcdir}/ ( [\w-]+ ) - v? ( [\d.]+ ) /? " / at /usr/bin/vendor_perl/cpan2aur line 771.

Oddly enough, the Arch package line is different, a diff:
```
% diff -u $(which cpan2aur) cpan2aur.new                                [08/18/15][20:17:52])
--- /usr/bin/vendor_perl/cpan2aur       2015-03-20 14:05:13.000000000 -0600
+++ cpan2aur.new        2015-08-18 20:10:11.754247276 -0600
@@ -1,8 +1,5 @@
 #!/usr/bin/perl

-eval 'exec /usr/bin/perl  -S $0 ${1+"$@"}'
-    if 0; # not running under some shell
-
 use warnings;
 use strict;

@@ -768,7 +765,7 @@

     my ($dist_name, $dist_ver) = $pkgbuild_txt
         =~ m{ (?: DIST_DIR | ^_distdir )=
-              "\${srcdir}/ ( [\w-]+ ) - v? ( [\d.]+ ) /? " }xms;
+              "\$\{srcdir\}/ ( [\w-]+ ) - v? ( [\d.]+ ) /? " }xms;

     my ($pkgrel) = $pkgbuild_txt
         =~ m{ ^ pkgrel = ['"]? ( \d+ ) ['"]? }xms;
```

Shows the "not running under some shell" hack... Not sure if you want to throw that in there as well.
I tested my changes and it seems to be fine, I'll let you do some further testing.